### PR TITLE
Fix for " setup_msgs causes a section type conflict with __c"

### DIFF
--- a/Arduino/libraries/RBL_BLEShield/ble_shield.cpp
+++ b/Arduino/libraries/RBL_BLEShield/ble_shield.cpp
@@ -75,7 +75,7 @@ However this removes the need to do the setup of the nRF8001 on every reset.*/
 #endif
 
 /* Store the setup for the nRF8001 in the flash of the AVR to save on RAM */
-static hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
+static const hal_aci_data_t setup_msgs[NB_SETUP_MESSAGES] PROGMEM = SETUP_MESSAGES_CONTENT;
 
 static char device_name[11] = "BLE Shield";
 
@@ -147,7 +147,7 @@ void ble_begin()
 				aci_state.aci_setup_info.services_pipe_type_mapping = NULL;
 		 }
 		aci_state.aci_setup_info.number_of_pipes    = NUMBER_OF_PIPES;
-		aci_state.aci_setup_info.setup_msgs         = setup_msgs;
+		aci_state.aci_setup_info.setup_msgs         = (hal_aci_data_t*)setup_msgs;
 		aci_state.aci_setup_info.num_setup_msgs     = NB_SETUP_MESSAGES;
 
 			/*


### PR DESCRIPTION
Fix for " setup_msgs causes a section type conflict with __c". I just bought a BLE Shield 2. The library would not compile using Arduino 1.0.5. The same issue was documented in this forum entry:
https://redbearlab.zendesk.com/entries/23440476-Getting-Started

In the latest version of Arduino, the new avr gcc requires that PROGMEM use include the const modifier. This causes a section type conflict error as reported by some users of the shield. As a result, I couldn't get this shield working with my Arduino Duemilanove without this change. Full documentation on what fixed the error can be found here: http://www.avrfreaks.net/index.php?name=PNphpBB2&file=viewtopic&t=38003.
