### PR TITLE
fixed firmata sketch for case-sensitive filesystems

### DIFF
--- a/Arduino/libraries/RBL_BLEShield/examples/BLEFirmataSketch/BLEFirmata.cpp
+++ b/Arduino/libraries/RBL_BLEShield/examples/BLEFirmataSketch/BLEFirmata.cpp
@@ -14,7 +14,7 @@
 //* Includes
 //******************************************************************************
 
-#include "BleFirmata.h"
+#include "BLEFirmata.h"
 #include "HardwareSerial.h"
 #include "ble_shield.h"
 


### PR DESCRIPTION
Hi guys, just a quick fix to make your BLEFirmata example work for case-sensitive filesystems, i.e. Linux
